### PR TITLE
fix(pod-flavor): memory metric used by oomkiller

### DIFF
--- a/kubernetes-pods-aggregated-view.json
+++ b/kubernetes-pods-aggregated-view.json
@@ -446,7 +446,7 @@
             {
               "datasource": "${datasource}",
               "exemplar": true,
-              "expr": "container_memory_usage_bytes{pod=~\"[[pod_name]].*\", namespace=\"$namespace\", cluster=~\"$cluster.*\", image!=\"\", pod!=\"\", container!=\"POD\", container!=\"\"}\n",
+              "expr": "container_memory_working_set_bytes{pod=~\"[[pod_name]].*\", namespace=\"$namespace\", cluster=~\"$cluster.*\", image!=\"\", pod!=\"\", container!=\"POD\", container!=\"\"}\n",
               "interval": "",
               "legendFormat": "{{ pod }}",
               "refId": "A"

--- a/kubernetes-pods-wiremind-flavor.json
+++ b/kubernetes-pods-wiremind-flavor.json
@@ -146,7 +146,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "container_memory_usage_bytes{job=\"kubelet\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", container=~\"$container\", container!=\"POD\"}",
+          "expr": "container_memory_working_set_bytes{job=\"kubelet\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", container=~\"$container\", container!=\"POD\"}",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,

--- a/postgresql-database.json
+++ b/postgresql-database.json
@@ -781,7 +781,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "container_memory_usage_bytes{namespace=\"$namespace\", pod=\"$pod\", container!=\"metrics-exporter\", container!=\"POD\", container!=\"\"}",
+          "expr": "container_memory_working_set_bytes{namespace=\"$namespace\", pod=\"$pod\", container!=\"metrics-exporter\", container!=\"POD\", container!=\"\"}",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,


### PR DESCRIPTION
> You might think that memory utilization is easily tracked with container_memory_usage_bytes, however, this metric also includes cached (think filesystem cache) items that can be evicted under memory pressure. The better metric is container_memory_working_set_bytes as this is what the OOM killer is watching for.

- https://faun.pub/how-much-is-too-much-the-linux-oomkiller-and-used-memory-d32186f29c9d
- https://github.com/google/cadvisor/blob/master/docs/storage/prometheus.md