### PR TITLE
fix(agentgateway): label daily token bars by the day they cover

### DIFF
--- a/agentgateway.json
+++ b/agentgateway.json
@@ -259,7 +259,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum by (gen_ai_token_type) (increase(agentgateway_gen_ai_client_token_usage_sum{cluster=~\"$cluster\",namespace=~\"$namespace\"}[$__interval]))",
+          "expr": "sum by (gen_ai_token_type) (increase(agentgateway_gen_ai_client_token_usage_sum{cluster=~\"$cluster\",namespace=~\"$namespace\"}[$__interval] offset -$__interval))",
           "legendFormat": "{{gen_ai_token_type}}",
           "range": true,
           "refId": "A"
@@ -353,7 +353,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum by (namespace) (increase(agentgateway_gen_ai_client_token_usage_sum{cluster=~\"$cluster\",namespace=~\"$namespace\"}[$__interval]))",
+          "expr": "sum by (namespace) (increase(agentgateway_gen_ai_client_token_usage_sum{cluster=~\"$cluster\",namespace=~\"$namespace\"}[$__interval] offset -$__interval))",
           "legendFormat": "{{namespace}}",
           "range": true,
           "refId": "A"
@@ -447,7 +447,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum by (gen_ai_request_model) (increase(agentgateway_gen_ai_client_token_usage_sum{cluster=~\"$cluster\",namespace=~\"$namespace\"}[$__interval]))",
+          "expr": "sum by (gen_ai_request_model) (increase(agentgateway_gen_ai_client_token_usage_sum{cluster=~\"$cluster\",namespace=~\"$namespace\"}[$__interval] offset -$__interval))",
           "legendFormat": "{{gen_ai_request_model}}",
           "range": true,
           "refId": "A"
@@ -541,7 +541,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum by (namespace,gen_ai_request_model) (increase(agentgateway_gen_ai_server_request_duration_count{cluster=~\"$cluster\",namespace=~\"$namespace\"}[$__interval]))",
+          "expr": "sum by (namespace,gen_ai_request_model) (increase(agentgateway_gen_ai_server_request_duration_count{cluster=~\"$cluster\",namespace=~\"$namespace\"}[$__interval] offset -$__interval))",
           "legendFormat": "{{namespace}} {{gen_ai_request_model}}",
           "range": true,
           "refId": "A"
@@ -711,7 +711,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum by (namespace,workflow) (increase(agentgateway_gen_ai_client_token_usage_sum{cluster=~\"$cluster\",namespace=~\"$namespace\"}[$__interval]))",
+          "expr": "sum by (namespace,workflow) (increase(agentgateway_gen_ai_client_token_usage_sum{cluster=~\"$cluster\",namespace=~\"$namespace\"}[$__interval] offset -$__interval))",
           "legendFormat": "{{namespace}} {{workflow}}",
           "range": true,
           "refId": "A"

--- a/agentgateway.json
+++ b/agentgateway.json
@@ -2126,7 +2126,7 @@
   },
   "time": {
     "from": "now-7d",
-    "to": "now"
+    "to": "now+1d"
   },
   "timepicker": {},
   "timezone": "browser",


### PR DESCRIPTION
## Problem

The five bar-chart panels of the AgentGateway dashboard plot each daily aggregate one day later than the day it covers.

All five pin the bucket to a day:

```json
"interval": "1d",
"expr": "sum by (...) (increase(agentgateway_gen_ai_client_token_usage_sum{...}[$__interval]))"
```

`interval: "1d"` fixes both `$__interval` and the query step at one day. A range-query point at time `T` is therefore `increase` over the trailing window `(T-1d, T]` — but the bar chart draws it at `x = T`, so the bar labelled 08/28 holds 08/27's tokens.

The giveaway on a typical week: the two zero bars land on Sunday and Monday instead of Saturday and Sunday.

Separately, the current day was not visible at all. Grafana aligns the daily grid to UTC midnight and pulls both ends of the range inward, so with the saved `to=now` the newest grid point is yesterday. Reading today meant hand-editing the URL to `to=now+2d`, which — combined with the labelling bug — rendered a bar under *tomorrow's* date and read as consumption in the future.

## Fix

Two changes.

**1. Label each bucket by the day it covers.** A negative offset moves each window forward so the point is labelled by its start:

```
increase(agentgateway_gen_ai_client_token_usage_sum{...}[$__interval] offset -$__interval)
```

Applied to panels 7, 8, 9, 10 and 32.

**2. Extend the saved range to `now-7d` → `now+1d`** so the grid includes the current day. The offset alone does not achieve this: it corrects which day a bar is labelled with, not which days are in the grid.

The `timeseries` panels that also use `increase(...[$__interval])` (Requests over Time, Requests by Status, MCP Tool Calls) are deliberately left alone: at 1h granularity a point meaning "the hour before `T`" is the usual convention and does not mislead the way a dated bar does. The `$__range` stat and bar-gauge totals are unaffected by bucket labelling.

## Verification

Checked in Explore against the Thanos datasource, step 1d, query inspector → Data. With the offset, input tokens per bucket:

| timestamp (local) | value |
|---|---|
| 2026-08-22 02:00 | 0 |
| 2026-08-23 02:00 | 0 |
| 2026-08-24 02:00 | 9 986 538 |
| 2026-08-25 02:00 | 20 402 024 |
| 2026-08-26 02:00 | 49 231 015 |
| 2026-08-27 02:00 | 30 244 459 |

The two zeros now fall on Saturday 08/22 and Sunday 08/23; before the fix they sat on Sunday/Monday. With `to=now` the series ends at 08/27 as shown; with `to=now+1d` an 08/28 point appears carrying today's running total.

## Notes for reviewers

- **Buckets are UTC days, not local days.** Every grid point lands on 00:00 UTC (02:00 local in Paris), so a bar labelled 08/27 spans 02:00 08/27 → 02:00 08/28 local. Pre-existing, neither caused nor fixed here, but it means the bars are not exactly business days.
- **`offset` with a negative duration needs the `promql-negative-offset` feature.** It is enabled on the Wiremind Thanos (verified above). On a Prometheus or Thanos without it these five queries will error — relevant since this repo is public.
- An alternative fix avoiding the negative offset entirely would be to convert these five `barchart` panels to `timeseries` with `drawStyle: bars` and `barAlignment: -1`, so each bar spans the interval preceding its timestamp. That is a much larger diff; happy to go that way instead if preferred.
