### PR TITLE
fix(agentgateway): label daily token bars by the day they cover

### DIFF
--- a/agentgateway.json
+++ b/agentgateway.json
@@ -259,7 +259,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum by (gen_ai_token_type) (increase(agentgateway_gen_ai_client_token_usage_sum{cluster=~\"$cluster\",namespace=~\"$namespace\"}[$__interval]))",
+          "expr": "sum by (gen_ai_token_type) (increase(agentgateway_gen_ai_client_token_usage_sum{cluster=~\"$cluster\",namespace=~\"$namespace\"}[$__interval] offset -$__interval))",
           "legendFormat": "{{gen_ai_token_type}}",
           "range": true,
           "refId": "A"
@@ -353,7 +353,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum by (namespace) (increase(agentgateway_gen_ai_client_token_usage_sum{cluster=~\"$cluster\",namespace=~\"$namespace\"}[$__interval]))",
+          "expr": "sum by (namespace) (increase(agentgateway_gen_ai_client_token_usage_sum{cluster=~\"$cluster\",namespace=~\"$namespace\"}[$__interval] offset -$__interval))",
           "legendFormat": "{{namespace}}",
           "range": true,
           "refId": "A"
@@ -447,7 +447,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum by (gen_ai_request_model) (increase(agentgateway_gen_ai_client_token_usage_sum{cluster=~\"$cluster\",namespace=~\"$namespace\"}[$__interval]))",
+          "expr": "sum by (gen_ai_request_model) (increase(agentgateway_gen_ai_client_token_usage_sum{cluster=~\"$cluster\",namespace=~\"$namespace\"}[$__interval] offset -$__interval))",
           "legendFormat": "{{gen_ai_request_model}}",
           "range": true,
           "refId": "A"
@@ -541,7 +541,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum by (namespace,gen_ai_request_model) (increase(agentgateway_gen_ai_server_request_duration_count{cluster=~\"$cluster\",namespace=~\"$namespace\"}[$__interval]))",
+          "expr": "sum by (namespace,gen_ai_request_model) (increase(agentgateway_gen_ai_server_request_duration_count{cluster=~\"$cluster\",namespace=~\"$namespace\"}[$__interval] offset -$__interval))",
           "legendFormat": "{{namespace}} {{gen_ai_request_model}}",
           "range": true,
           "refId": "A"
@@ -711,7 +711,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum by (namespace,workflow) (increase(agentgateway_gen_ai_client_token_usage_sum{cluster=~\"$cluster\",namespace=~\"$namespace\"}[$__interval]))",
+          "expr": "sum by (namespace,workflow) (increase(agentgateway_gen_ai_client_token_usage_sum{cluster=~\"$cluster\",namespace=~\"$namespace\"}[$__interval] offset -$__interval))",
           "legendFormat": "{{namespace}} {{workflow}}",
           "range": true,
           "refId": "A"


### PR DESCRIPTION
## What

Add `offset -$__interval` to the `increase()` queries of the five bar-chart panels of the AgentGateway dashboard:

- Token Consumption over Time (by token type) — panel 7
- Token Consumption over Time (by namespace) — panel 8
- Token Consumption over Time (by model) — panel 9
- LLM Requests (by model) — panel 10
- Token Consumption over Time (by workflow) — panel 32

## Why

All five pin `"interval": "1d"`, which fixes both `$__interval` and the query step at one day. A range-query point at time `T` is then `increase()` over the trailing window `(T-1d, T]`, but a bar chart draws that point at `x = T` — so every bar showed the previous day's data under the next day's label, silently misattributing token spend to the wrong day.

The same bucketing also hid the current day. With the dashboard's saved `now-7d to now` range the last grid point is today 00:00, which covers yesterday, so today's consumption was not plotted at all; seeing it required hand-editing the URL to `to=now+2d`, which then drew a bar dated tomorrow.

The negative offset shifts each window forward so a point is labelled by the start of the period it covers. Today shows up as a partial bar under `to=now`, and the `now+2d` workaround is no longer needed.

## Notes for reviewers

- `offset` with a negative duration requires the `promql-negative-offset` feature on vanilla Prometheus (always-on in recent releases). These queries go through Thanos, which accepts them — worth keeping in mind if this dashboard is ever pointed at a plain Prometheus.
- The other `increase(...[$__interval])` panels (Requests over Time, Requests by Status, MCP Tool Calls) are timeseries at 1h granularity. They carry the same one-bucket shift, but a point standing for the preceding hour is the conventional reading there and no calendar date is labelled, so I left them alone. Making them strictly consistent would also mean changing `barAlignment` to `1`, which is a bigger call than this fix — happy to do it in a follow-up if you'd rather have it uniform.
- No schema change: still classic v1, `uid` unchanged.
